### PR TITLE
capture a couple more environ vars

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -11,8 +11,8 @@ on:
 jobs:
   test:
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -25,7 +25,8 @@ jobs:
           path: .artifacts/junit.xml
           gcs_path: ${{ secrets.GCS_BUCKET }}/self-test/${{ github.run_id }}
           gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
-          workload_identity_provider: ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
+          workload_identity_provider:
+            ${{ secrets.SENTRY_GCP_DEV_WORKLOAD_IDENTITY_POOL }}
           service_account_email: ${{ secrets.SUDO_GCP_SERVICE_ACCOUNT }}
 
       - name: Check Output

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -31,6 +31,9 @@ jobs:
 
       - name: Check Output
         run: |
+          # use this step's log as the summary:
+          exec > >(tee -a "$GITHUB_STEP_SUMMARY") 2>&1
+
           # Check that both files were uploaded (using the output from the action)
           files="${{ steps.test-action.outputs.uploaded }}"
           if [[ $files != *'junit.xml'* ]]; then
@@ -42,3 +45,14 @@ jobs:
             exit 1
           fi
           echo "Files uploaded successfully"
+
+          set -x
+          metadata=test-data/metadata.json
+
+          test $(jq <"$metadata" -r .env.GITHUB_JOB_NAME) = "test"
+          test $(jq <"$metadata" -r .env.GITHUB_JOB_ID) -gt 0
+
+          : we have no matrix here, so this bit should be boring
+          test $(jq <"$metadata" -r .env.GITHUB_MATRIX) = "null"
+          test $(jq <"$metadata" -r .env.GITHUB_MATRIX_INDEX) -eq 0
+          test $(jq <"$metadata" -r .env.GITHUB_MATRIX_TOTAL) -eq 1

--- a/action.yml
+++ b/action.yml
@@ -25,29 +25,45 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Create directory
-      id: create-directory
-      shell: bash
-      run: mkdir -p test-data
+    - name: set more GITHUB_ vars
+      shell: bash -euo pipefail {0}
+      env:
+        GITHUB_MATRIX: ${{toJSON(matrix)}}
+        GITHUB_MATRIX_INDEX: ${{toJSON(strategy.job-index)}}
+        GITHUB_MATRIX_TOTAL: ${{toJSON(strategy.job-total)}}
 
-    - name: Copy files
-      id: copy-files
-      shell: bash
-      run: cp -r ${{ inputs.path }} test-data
+        # required for the below API call
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        job=$(
+          gh api repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs |
+            jq --arg runner_name "$RUNNER_NAME" \
+              '.jobs[] | select(.runner_name == $runner_name)'
+        )
+
+        echo The missing GITHUB_ environment variables:
+        tee -a "$GITHUB_ENV" <<EOF
+        GITHUB_JOB_ID=$(jq -r .id <<< "$job")
+        GITHUB_JOB_NAME=$(jq -r .name <<< "$job")
+        GITHUB_MATRIX=$(jq -c <<<"$GITHUB_MATRIX")
+        GITHUB_MATRIX_INDEX=$GITHUB_MATRIX_INDEX
+        GITHUB_MATRIX_TOTAL=$GITHUB_MATRIX_TOTAL
+        EOF
 
     - name: Setup Python
       uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: "3.11"
 
-    - name: Collect metadata
-      id: collect-metadata
-      shell: bash
+    - name: Prepare
+      shell: bash -euo pipefail {0}
       run: |
+        set -x
+        mkdir -p test-data
+        cp -r ${{ inputs.path }} test-data
         python3 -uS ${{ github.action_path }}/bin/generate-metadata.py > test-data/metadata.json
 
     - name: Authenticate
-      id: auth
       uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
       with:
         project_id: ${{ inputs.gcp_project_id }}

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: 'Collect Test Data'
-description: 'Collect test data and metadata and upload them to GCS.'
+name: "Collect Test Data"
+description: "Collect test data and metadata and upload them to GCS."
 inputs:
   path:
-    description: 'The path to the test output (such as a JUnit XML file).'
+    description: "The path to the test output (such as a JUnit XML file)."
     required: true
   gcs_path:
     description: |
@@ -10,20 +10,20 @@ inputs:
       The format is bucket-name[/prefix]. You don't need to include the gs:// prefix.
     required: true
   gcp_project_id:
-    description: 'The GCP project ID to use for authentication.'
+    description: "The GCP project ID to use for authentication."
     required: true
   workload_identity_provider:
-    description: 'The workload identity provider to use for authentication.'
+    description: "The workload identity provider to use for authentication."
     required: true
   service_account_email:
-    description: 'The service account email to use for authentication.'
+    description: "The service account email to use for authentication."
     required: true
 outputs:
   uploaded:
-    description: 'The list of files uploaded to GCS.'
+    description: "The list of files uploaded to GCS."
     value: ${{ steps.upload.outputs.uploaded }}
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Create directory
       id: create-directory
@@ -34,11 +34,11 @@ runs:
       id: copy-files
       shell: bash
       run: cp -r ${{ inputs.path }} test-data
-    
+
     - name: Setup Python
       uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.11'
+        python-version: "3.11"
 
     - name: Collect metadata
       id: collect-metadata
@@ -54,7 +54,7 @@ runs:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account_email }}
 
-    - name: Upload 
+    - name: Upload
       id: upload
       uses: google-github-actions/upload-cloud-storage@22121cd842b0d185e042e28d969925b538c33d77 # v2.1.0
       with:

--- a/bin/generate-metadata.py
+++ b/bin/generate-metadata.py
@@ -40,14 +40,14 @@ def generate_test_metadata():
     gr = grp.getgrgid(gid)
 
     return {
-      "cwd": os.getcwd(),
-      "host": socket.getfqdn(),
-      "uid": uid,
-      "username": pw.pw_name,
-      "home": pw.pw_dir,
-      "gid": gid,
-      "group": gr.gr_name,
-      "env": get_env(dict(os.environ)),
+        "cwd": os.getcwd(),
+        "host": socket.getfqdn(),
+        "uid": uid,
+        "username": pw.pw_name,
+        "home": pw.pw_dir,
+        "gid": gid,
+        "group": gr.gr_name,
+        "env": get_env(dict(os.environ)),
     }
 
 

--- a/bin/generate-metadata.py
+++ b/bin/generate-metadata.py
@@ -23,6 +23,8 @@ def relevant_env_var(var: str) -> bool:
             "GITHUB",
             "RUNNER",
             "CI",
+            "MATRIX",
+            "TEST",
         )
     )
 


### PR DESCRIPTION
This builds on https://github.com/getsentry/action-collect-test-data/pull/4

currently we can't differentiate otherwise-identical test-results without these env vars.

This change sets a few "GITHUB_" environment variables that github "should" really bet setting already:

* GITHUB_MATRIX: the compacted json of the current matrix slice
* GITHUB_MATRIX_INDEX: a reliable zero-index of the current matrix job
* GITHUB_MATRIX_TOTAL: a reliable count of matrix jobs
* GITHUB_JOB_NAME: the "Complete job name" as seen in the raw log, with parenthesized matrix disambiguation
* GITHUB_JOB_ID: i.e. the final number in the URL to a job's log